### PR TITLE
Bind DataGrid to ViewModels

### DIFF
--- a/src/Shoo/ViewModels/MainWindowViewModel.fs
+++ b/src/Shoo/ViewModels/MainWindowViewModel.fs
@@ -46,7 +46,9 @@ module MainWindowViewModel =
             IsActive = false
             Files = ObservableCollection()
         }
-        |> withoutCommand
+        // Immediately add an item to the collection to avoid having to go through the motions in
+        // the application
+        |> asFst (Cmd.ofMsg (AddFile ...a file path that exists...))
 
     let update tryPickFolder message model =
         match message with
@@ -78,6 +80,10 @@ module MainWindowViewModel =
         | ChangeActive active -> { model with IsActive = active } |> withoutCommand
         | Terminate -> model |> withoutCommand
         | AddFile path ->
+            // The DataGridColumn bindings work for this.
+            let vm = FileViewModel.designVM
+
+            // The DataGridColumn bindings do not work for this.
             let vm = FileViewModel.vm path
 
             model.Files.Add(vm)


### PR DESCRIPTION
I've been looking at Elmish.Avalonia, and the example application has been very helpful in getting started. However I've now hit the first issue it doesn't have answers for, and what I thought should work doesn't.

I'm adding items to an ObservableCollection which is the ItemsSource for a DataGrid. These have values that need to be updated over time, so they need to be ViewModels, rather than e.g. F# records. This works with a design instance, both in in the design view in Visual Studio and in the running program. It does not work, however, when using a ViewModel created via `AvaloniaProgram.mkSimple` with the same bindings. There is visibly an item added to the items source, but none of the bindings work. My guess is that the way of creating the item ViewModel may not be correct for this purpose, but I haven't been able to find an alternative that gives me the same Elmish loop.