### PR TITLE
Updated to Elmish.Avalonia v2.0.0-gamma.2

### DIFF
--- a/src/Shoo/App.axaml.fs
+++ b/src/Shoo/App.axaml.fs
@@ -18,11 +18,8 @@ type App() =
     override this.OnFrameworkInitializationCompleted() =
         match this.ApplicationLifetime with
         | :? IClassicDesktopStyleApplicationLifetime as desktop ->
-            let view = MainWindowView()
-            desktop.MainWindow <- view
-            Services.Init view
-            let vm = new ViewModels.MainWindowViewModel()
-            vm.StartElmishLoop(view)
+            let appRoot = AppCompositionRoot()
+            desktop.MainWindow <- appRoot.GetMainWindow<ViewModels.MainWindowViewModel, Views.MainWindowView>()
         | _ ->
             // leave this here for design view re-renders
             ()

--- a/src/Shoo/AppCompositionRoot.fs
+++ b/src/Shoo/AppCompositionRoot.fs
@@ -1,0 +1,20 @@
+﻿namespace Shoo
+
+open System
+open Elmish.Avalonia
+open Microsoft.Extensions.DependencyInjection
+open Shoo.ViewModels
+open Shoo.Views
+
+type AppCompositionRoot() = 
+    inherit CompositionRoot()
+
+    let mainView = MainWindowView()
+
+    override this.RegisterServices(services) = 
+        services.AddSingleton<Services.FolderPickerService>(Services.FolderPickerService(mainView))
+
+    override this.RegisterViews() = 
+        Map [
+            VM.Create<MainWindowViewModel>(), View.Singleton(mainView)
+        ]

--- a/src/Shoo/Services/FolderPickerService.fs
+++ b/src/Shoo/Services/FolderPickerService.fs
@@ -1,9 +1,6 @@
-namespace Shoo
+namespace Shoo.Services
 
 open System
-
-open Microsoft.Extensions.DependencyInjection
-
 open Avalonia.Controls
 open Avalonia.Platform.Storage
 
@@ -27,17 +24,3 @@ type FolderPickerService(mainWindow: Window) =
 
                         uri.AbsolutePath)
         }
-
-type Services() =
-    static let mutable container : IServiceProvider = null
-
-    static member Container
-        with get() = container
-
-    static member Init mainWindow =
-        let services = ServiceCollection()
-        services.AddSingleton<FolderPickerService>(FolderPickerService(mainWindow)) |> ignore
-        container <- services.BuildServiceProvider()
-
-    static member Get<'Svc>() =
-        container.GetRequiredService<'Svc>()

--- a/src/Shoo/Shoo.fsproj
+++ b/src/Shoo/Shoo.fsproj
@@ -15,7 +15,7 @@
     <Compile Include="Prelude.fs" />
     <Compile Include="Services\FolderPickerService.fs" />
     <Compile Include="ViewModels\ReactiveViewModelBase.fs" />
-    <Compile Include="ViewModels\FileViewModel.fs" />
+    <Compile Include="ViewModels\FileOperationViewModel.fs" />
     <Compile Include="ViewModels\MainWindowViewModel.fs" />
     <Compile Include="Views\MainWindowView.axaml.fs" />
     <Compile Include="UIUtilities.fs" />

--- a/src/Shoo/Shoo.fsproj
+++ b/src/Shoo/Shoo.fsproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Models\" />
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
 
@@ -21,6 +20,7 @@
     <Compile Include="Views\MainWindowView.axaml.fs" />
     <Compile Include="UIUtilities.fs" />
     <Compile Include="ViewLocator.fs" />
+    <Compile Include="AppCompositionRoot.fs" />
     <Compile Include="App.axaml.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
@@ -33,9 +33,8 @@
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.5" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.5" />
-    <PackageReference Include="Elmish.Avalonia" Version="2.0.0-gamma.1" />
+    <PackageReference Include="Elmish.Avalonia" Version="2.0.0-gamma.2" />
     <PackageReference Include="FSharp.Control.Reactive" Version="5.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="ReactiveUI" Version="18.4.44" />
   </ItemGroup>
 </Project>

--- a/src/Shoo/ViewLocator.fs
+++ b/src/Shoo/ViewLocator.fs
@@ -17,11 +17,13 @@ type ViewLocator() =
             if isNull viewType then
                 upcast TextBlock(Text = sprintf "Not Found: %s" name)
             else
-                let vm = data :?> IElmishViewModel
                 let view = downcast Activator.CreateInstance(viewType)
-                vm.StartElmishLoop(view)
-                view
+                match data with 
+                | :? ReactiveUI.ReactiveObject as vm ->
+                    ViewBinder.bindWithDispose (vm, view) |> snd
+                | _ ->
+                    TextBlock(Text = sprintf $"Not found: %s{name}")
 
         member this.Match(data) =
-            // Only apply this IDataTemplate when data is an IElmishViewModel
-            data :? IElmishViewModel
+            // Only apply this IDataTemplate when data is an ReactiveObject
+            data :? ReactiveUI.ReactiveObject

--- a/src/Shoo/ViewModels/FileOperationViewModel.fs
+++ b/src/Shoo/ViewModels/FileOperationViewModel.fs
@@ -8,15 +8,15 @@ open Elmish.Avalonia
 
 type MoveFileStatus = Waiting | Moving | Complete | Failed
 
-module File =
+module private FileOperation =
     type Model =
         {
             FullName: string
             FileName: string
             Time: DateTime
             FileSize: int64
-            MoveProgress: int
-            MoveStatus: MoveFileStatus
+            Progress: int
+            Status: MoveFileStatus
         }
 
     type Message =
@@ -25,8 +25,8 @@ module File =
 
     let update message model =
         match message with
-        | UpdateProgress progress -> { model with MoveProgress = progress }
-        | UpdateStatus status -> { model with MoveStatus = status }
+        | UpdateProgress progress -> { model with Progress = progress }
+        | UpdateStatus status -> { model with Status = status }
 
     let init path () =
         let fileInfo = FileInfo path
@@ -36,13 +36,13 @@ module File =
             FileName = fileInfo.Name
             Time = fileInfo.LastWriteTime
             FileSize = fileInfo.Length
-            MoveProgress = 0
-            MoveStatus = Waiting
+            Progress = 0
+            Status = Waiting
         }
 
-open File
+open FileOperation
 
-type FileViewModel(path: string) =
+type FileOperationViewModel(path: string) =
     inherit ReactiveElmishViewModel()
      
     let store = 
@@ -50,19 +50,18 @@ type FileViewModel(path: string) =
         |> Program.withErrorHandler (fun (_, ex) -> printfn "Error: %s" ex.Message)
         |> Program.withConsoleTrace
         |> Program.mkStore
-        
 
     member this.FullName = this.Bind(store, _.FullName)
     member this.FileName = this.Bind(store, _.FileName)
     member this.Time = this.Bind(store, _.Time)
     member this.FileSize = this.Bind(store, _.FileSize)
 
-    member this.MoveProgress
-        with get () = this.Bind(store, _.MoveProgress)
+    member this.Progress
+        with get () = this.Bind(store, _.Progress)
         and set value = store.Dispatch (UpdateProgress value)
 
-    member this.MoveStatus
-        with get () = this.Bind(store, _.MoveStatus)
+    member this.Status
+        with get () = this.Bind(store, _.Status)
         and set value = store.Dispatch (UpdateStatus value)
 
-    static member DesignVM = new FileViewModel(@"c:\hiberfil.sys", MoveProgress = 12, MoveStatus = Failed)
+    static member DesignVM = new FileOperationViewModel(@"c:\hiberfil.sys", Progress = 12, Status = Failed)

--- a/src/Shoo/ViewModels/FileViewModel.fs
+++ b/src/Shoo/ViewModels/FileViewModel.fs
@@ -43,25 +43,26 @@ module File =
 open File
 
 type FileViewModel(path: string) =
-    inherit ReactiveElmishViewModel<Model, Message>(init path ())
-
-    member this.FullName = this.Bind _.FullName
-    member this.FileName = this.Bind _.FileName
-    member this.Time = this.Bind _.Time
-    member this.FileSize = this.Bind _.FileSize
-
-    member this.MoveProgress
-        with get () = this.Bind _.MoveProgress
-        and set value = this.Dispatch (UpdateProgress value)
-
-    member this.MoveStatus
-        with get () = this.Bind _.MoveStatus
-        and set value = this.Dispatch (UpdateStatus value)
-
-    override this.StartElmishLoop(view: Avalonia.Controls.Control) =
+    inherit ReactiveElmishViewModel()
+     
+    let store = 
         Program.mkAvaloniaSimple (init path) update
         |> Program.withErrorHandler (fun (_, ex) -> printfn "Error: %s" ex.Message)
         |> Program.withConsoleTrace
-        |> Program.runView this view
+        |> Program.mkStore
+        
+
+    member this.FullName = this.Bind(store, _.FullName)
+    member this.FileName = this.Bind(store, _.FileName)
+    member this.Time = this.Bind(store, _.Time)
+    member this.FileSize = this.Bind(store, _.FileSize)
+
+    member this.MoveProgress
+        with get () = this.Bind(store, _.MoveProgress)
+        and set value = store.Dispatch (UpdateProgress value)
+
+    member this.MoveStatus
+        with get () = this.Bind(store, _.MoveStatus)
+        and set value = store.Dispatch (UpdateStatus value)
 
     static member DesignVM = new FileViewModel(@"c:\hiberfil.sys", MoveProgress = 12, MoveStatus = Failed)

--- a/src/Shoo/ViewModels/MainWindowViewModel.fs
+++ b/src/Shoo/ViewModels/MainWindowViewModel.fs
@@ -124,6 +124,9 @@ module Main =
 
         copyOperation.FileViewModel, 100, moveStatus
 
+    let hasPendingOperations (fileQueue: FileOperationViewModel seq) =
+        fileQueue |> Seq.exists (fun f -> f.Progress < 100)
+
     let update message model =
         match message with
         | UpdateSourceDirectory value ->
@@ -181,8 +184,8 @@ module Main =
                 watcher.Dispose()
                 subscription.Dispose())
 
-        /// Looks for a pending file copy and executes it.
-        let copyFileSub dispatch =
+        /// Processes the pending file operation.
+        let processQueueSub dispatch =
             model.FileQueue 
             |> Seq.tryFind (fun f -> f.Progress < 100)
             |> Option.iter (fun pfo ->
@@ -197,8 +200,8 @@ module Main =
             if model.IsActive then
                 [ nameof watchFileSystemSub ], watchFileSystemSub
 
-                if model.FileQueue |> Seq.exists (fun f -> f.Progress < 100) then
-                    [ nameof copyFileSub ], copyFileSub
+                if model.FileQueue |> hasPendingOperations then
+                    [ nameof processQueueSub ], processQueueSub
         ]
 
 open Main

--- a/src/Shoo/ViewModels/MainWindowViewModel.fs
+++ b/src/Shoo/ViewModels/MainWindowViewModel.fs
@@ -235,7 +235,7 @@ type MainWindowViewModel(folderPicker: Services.FolderPickerService) as this =
         with get () = this.Bind(store, _.IsActive)
         and set value = store.Dispatch(ChangeActive value)
 
-    member this.Files = this.Bind(store, _.FileQueue)
+    member this.FileQueue = this.Bind(store, _.FileQueue)
 
     member this.SelectSourceDirectory() = 
         task {

--- a/src/Shoo/Views/MainWindowView.axaml
+++ b/src/Shoo/Views/MainWindowView.axaml
@@ -120,7 +120,7 @@
 
         <DataGrid Grid.Row="2"
                   IsEnabled="{Binding IsActive}"
-                  ItemsSource="{Binding Files}">
+                  ItemsSource="{Binding FileQueue}">
             <DataGrid.Columns>
                 <DataGridTextColumn Width="*"
                                     Binding="{Binding FileName}"

--- a/src/Shoo/Views/MainWindowView.axaml
+++ b/src/Shoo/Views/MainWindowView.axaml
@@ -148,14 +148,14 @@
                             <Grid>
                                 <ProgressBar MinWidth="1"
                                              Margin="10 0"
-                                             Classes.Completed="{Binding MoveStatus,
+                                             Classes.Completed="{Binding Status,
                                                                          Converter={x:Static uiUtilities:ValueEqualsParameterConverter.Instance},
                                                                          ConverterParameter={x:Static vm:MoveFileStatus.Complete}}"
-                                             Classes.Failed="{Binding Path=MoveStatus,
+                                             Classes.Failed="{Binding Path=Status,
                                                                       Converter={x:Static uiUtilities:ValueEqualsParameterConverter.Instance},
                                                                       ConverterParameter={x:Static vm:MoveFileStatus.Failed}}"
                                              ShowProgressText="True"
-                                             Value="{Binding MoveProgress}" />
+                                             Value="{Binding Progress}" />
                             </Grid>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
* Updated latest Elmish.Avalonia
  * Updated to use new `Program.mkStore`
  * Added new `AppCompositionRoot` with service and view/vm registraiton
  * Constructor injected `FolderPickerService`
* Renamed `Files` to `FileQueue` 
* Renamed `FileViewModel` to `FileOperationViewModel`
* Reworked `subscriptions`:
  * Moved all IO functions out of the Elmish `update` and consolidated them into `subscriptions`
  * `watchFileSystemSub` now just adds a file operation to the queue (but doesn't start the copy)
  * `processQueueSub` runs if there are any pending file operations and does the operation (copy).
* Removed Rx subject (extra indirection is no longer needed)

